### PR TITLE
Restrict uploads to PDF or image files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ✅ **Vollständig offline** - Alle Daten bleiben in Ihrem Browser  
 ✅ **Flexible Erfassung** - Keine Pflichtfelder (außer Datum)  
-✅ **Dokumentenarchiv** - PDFs und Bilder direkt anhängen (bis 5MB)  
+✅ **Dokumentenarchiv** - Nur PDFs und Bilder (JPG/PNG) direkt anhängen (bis 5MB)
 ✅ **Live-Statistiken** - Übersicht nach Kategorien und Beträgen  
 ✅ **Einfacher Export** - ZIP mit allen Daten + Dokumenten  
 ✅ **Responsive Design** - Optimiert für Desktop & Mobile  
@@ -29,7 +29,7 @@ git clone https://github.com/TimInTech/Brief-Dashboard.git
 1. **Brief erfassen**:
    - Datum (automatisch vorausgefüllt)
    - Optionale Felder: Absender, Betreff, Betrag, Frist
-   - Dokumente anhängen (PDF/JPG/PNG)
+   - Dokumente anhängen (nur PDF, JPG oder PNG)
 
 2. **Verwalten**:
    - Filter nach Kategorie/Status

--- a/index.html
+++ b/index.html
@@ -289,13 +289,19 @@
       let dokumenteData = [];
       
       if (files.length > 0) {
+        const allowedTypes = ['application/pdf'];
         for (let i = 0; i < files.length; i++) {
           const file = files[i];
           if (file.size > 5 * 1024 * 1024) {
             alert(`Datei ${file.name} ist zu groß (max. 5MB)`);
             continue;
           }
-          
+
+          if (!(allowedTypes.includes(file.type) || file.type.startsWith('image/'))) {
+            alert(`Datei ${file.name} hat einen nicht unterstützten Dateityp. Erlaubt sind PDF und Bilder (JPG/PNG).`);
+            continue;
+          }
+
           const dataUrl = await readFileAsDataURL(file);
           dokumenteData.push({
             name: file.name,


### PR DESCRIPTION
## Summary
- limit accepted attachments to PDFs or images and alert on unsupported types
- document allowed file formats in README

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_688defb162088333a8334899f902b1d0

## Zusammenfassung von Sourcery

Beschränkt Anhang-Uploads auf nur PDF- und Bilddateien und aktualisiert die README, um die erlaubten Formate widerzuspiegeln.

Neue Funktionen:
- Dateityp-Validierung hinzugefügt, um nur PDFs und Bilder zu akzeptieren, mit Warnung bei nicht unterstützten Typen.

Dokumentation:
- Erlaubte Anhangsformate (PDF, JPG, PNG) und Größenbeschränkung in der README dokumentiert.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restrict attachment uploads to only PDF and image files and update the README to reflect the allowed formats

New Features:
- Add file type validation to accept only PDFs and images, alerting on unsupported types

Documentation:
- Document allowed attachment formats (PDF, JPG, PNG) and size limit in README

</details>